### PR TITLE
feat: add authentication middleware

### DIFF
--- a/caso-01/package.json
+++ b/caso-01/package.json
@@ -10,5 +10,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "mysql2": "^3.14.1"
+  }
 }

--- a/caso-01/utils/authMiddleware.js
+++ b/caso-01/utils/authMiddleware.js
@@ -1,0 +1,22 @@
+const FormatRes = require("./formatRes");
+
+export const authMiddleware = (req, res) => {
+  const response = new FormatRes(res);
+
+  const token = req.headers.authorization;
+
+  if (!token) {
+    response.unauthorized("Forbidden. No token provided.");
+    return false;
+  }
+
+  const expectedToken = process.env.AUTH_TOKEN || "secret-token";
+
+  if (token !== `Bearer ${expectedToken}`) {
+    response.forbidden("Forbidden. Invalid token.");
+    return false;
+  }
+
+  return true;
+};
+

--- a/caso-01/utils/authMiddleware.js
+++ b/caso-01/utils/authMiddleware.js
@@ -1,4 +1,4 @@
-const FormatRes = require("./formatRes");
+import { FormatRes } from "./formatRes.js";
 
 export const authMiddleware = (req, res) => {
   const response = new FormatRes(res);


### PR DESCRIPTION
Se implementa un middleware de autenticación que verifica la presencia de un token en el encabezado Authorization.

El middleware valida que el token sea igual a un valor esperado (Bearer secret-token). En caso de no estar presente o ser inválido, responde con un error 401 o 403 utilizando la clase FormatRes.  
Si el token es válido, retorna true y permite continuar con la ejecución.

Forma de uso: 
```javascript
  import { authMiddleware } from "../utils/authMiddleware";

  async createProduct(req, res) {
     if (!authMiddleware(req, res)) return; // Si es diferente a true, significa que el token no es válido

     try {...} ctach {...}
  }
``` 

En postman:
1. Ir a la pestaña Authorization.
![image](https://github.com/user-attachments/assets/b3d1b99e-5fcd-4903-b5c2-aa27b4dcf6d4)
2. Seleccionar Auth Type → Bearer Token.
![image](https://github.com/user-attachments/assets/d21fe902-b18f-421a-b5aa-15feb7314e79)
3. Escribir token.
`secret-token
`![image](https://github.com/user-attachments/assets/4df6ed56-006e-4009-8f6e-fd2209c663b1)
